### PR TITLE
backend: introduce new mem backend type

### DIFF
--- a/include/libubbd.h
+++ b/include/libubbd.h
@@ -37,6 +37,7 @@ enum ubbd_dev_type {
 	UBBD_DEV_TYPE_SSH,
 	UBBD_DEV_TYPE_CACHE,
 	UBBD_DEV_TYPE_S3,
+	UBBD_DEV_TYPE_MEM,
 	UBBD_DEV_TYPE_MAX,
 };
 
@@ -76,6 +77,8 @@ struct __ubbd_dev_info {
 			char volume_name[UBBD_NAME_MAX];
 			char bucket_name[UBBD_NAME_MAX];
 		} s3;
+		struct {
+		} mem;
 	};
 };
 
@@ -157,6 +160,8 @@ struct __ubbd_map_opts {
 			const char *volume_name;
 			const char *bucket_name;
 		} s3;
+		struct {
+		} mem;
 
 	};
 };

--- a/include/ubbd_backend.h
+++ b/include/ubbd_backend.h
@@ -76,6 +76,10 @@ struct ubbd_null_backend {
 	struct ubbd_backend ubbd_b;
 };
 
+struct ubbd_mem_backend {
+	struct ubbd_backend ubbd_b;
+};
+
 struct ubbd_file_backend {
 	struct ubbd_backend ubbd_b;
 	char filepath[UBBD_PATH_MAX];

--- a/include/ubbd_config.h
+++ b/include/ubbd_config.h
@@ -15,10 +15,6 @@ struct ubbd_conf_header {
 #define UBBD_CONF_TYPE_BACKEND		1
 #define UBBD_CONF_TYPE_DEVICE		2
 
-#define UBBD_CONF_TYPE_RBD_BACKEND	1
-#define UBBD_CONF_TYPE_FILE_BACKEND	2
-#define UBBD_CONF_TYPE_NULL_BACKEND	3
-
 struct ubbd_dev_conf {
 	struct ubbd_conf_header conf_header;
 	enum ubbd_dev_type dev_type;

--- a/include/ubbd_dev.h
+++ b/include/ubbd_dev.h
@@ -16,6 +16,10 @@
 #define UBBD_DEV_RESTART_MODE_DEV	1
 #define UBBD_DEV_RESTART_MODE_QUEUE	2
 
+#define	UBBD_MEM_BLK_SIZE	(1024 * 1024)
+#define	UBBD_MEM_BLK_SHIFT	20
+#define	UBBD_MEM_BLK_MASK	0xFFFFF
+#define	UBBD_MEM_BLK_COUNT	(100 * 1024)
 
 enum ubbd_dev_ustatus {
 	UBBD_DEV_USTATUS_INIT,
@@ -89,6 +93,10 @@ struct ubbd_rbd_device {
 };
 
 struct ubbd_null_device {
+	struct ubbd_device ubbd_dev;
+};
+
+struct ubbd_mem_device {
 	struct ubbd_device ubbd_dev;
 };
 

--- a/lib/libubbd.c
+++ b/lib/libubbd.c
@@ -55,6 +55,8 @@ static enum ubbd_dev_type str_to_type(const char *str)
 		type = UBBD_DEV_TYPE_CACHE;
 	else if (!strcmp("s3", str))
 		type = UBBD_DEV_TYPE_S3;
+	else if (!strcmp("mem", str))
+		type = UBBD_DEV_TYPE_MEM;
 	else
 		type = -1;
 
@@ -178,6 +180,12 @@ void null_dev_info_setup(struct __ubbd_dev_info *info,
 	return;
 }
 
+void mem_dev_info_setup(struct __ubbd_dev_info *info,
+		struct __ubbd_map_opts *opts)
+{
+	return;
+}
+
 void s3_dev_info_setup(struct __ubbd_dev_info *info,
 		struct __ubbd_map_opts *opts)
 {
@@ -210,6 +218,8 @@ int generic_dev_info_setup(enum ubbd_dev_type dev_type,
 		ssh_dev_info_setup(info, opts);
 	} else if (dev_type == UBBD_DEV_TYPE_S3) {
 		s3_dev_info_setup(info, opts);
+	} else if (dev_type == UBBD_DEV_TYPE_MEM) {
+		mem_dev_info_setup(info, opts);
 	} else {
 		ubbd_err("error dev_type: %d\n", dev_type);
 		return -EINVAL;

--- a/lib/ubbd_backends/ubbd_backend.c
+++ b/lib/ubbd_backends/ubbd_backend.c
@@ -16,6 +16,7 @@ extern struct ubbd_backend_ops null_backend_ops;
 extern struct ubbd_backend_ops ssh_backend_ops;
 extern struct ubbd_backend_ops cache_backend_ops;
 extern struct ubbd_backend_ops s3_backend_ops;
+extern struct ubbd_backend_ops mem_backend_ops;
 
 struct ubbd_ssh_backend *create_ssh_backend(void)
 {
@@ -61,6 +62,22 @@ struct ubbd_null_backend *create_null_backend(void)
 	ubbd_b = &dev->ubbd_b;
 	ubbd_b->dev_type = UBBD_DEV_TYPE_NULL;
 	ubbd_b->backend_ops = &null_backend_ops;
+
+	return dev;
+}
+
+struct ubbd_mem_backend *create_mem_backend(void)
+{
+	struct ubbd_backend *ubbd_b;
+	struct ubbd_mem_backend *dev;
+
+	dev = calloc(1, sizeof(*dev));
+	if (!dev)
+		return NULL;
+
+	ubbd_b = &dev->ubbd_b;
+	ubbd_b->dev_type = UBBD_DEV_TYPE_MEM;
+	ubbd_b->backend_ops = &mem_backend_ops;
 
 	return dev;
 }
@@ -189,7 +206,7 @@ struct ubbd_backend *backend_create(struct __ubbd_dev_info *dev_info)
 			return NULL;
 		ubbd_b = &null_backend->ubbd_b;
 		ubbd_b->dev_size = dev_info->size;
-	}else if (dev_info->type == UBBD_DEV_TYPE_SSH){
+	} else if (dev_info->type == UBBD_DEV_TYPE_SSH){
 		struct ubbd_ssh_backend *ssh_backend;
 
 		ssh_backend = create_ssh_backend();
@@ -200,7 +217,7 @@ struct ubbd_backend *backend_create(struct __ubbd_dev_info *dev_info)
 		strcpy(ssh_backend->hostname, dev_info->ssh.hostname);
 		strcpy(ssh_backend->path, dev_info->ssh.path);
 		ubbd_b->dev_size = dev_info->size;
-	}else if (dev_info->type == UBBD_DEV_TYPE_S3){
+	} else if (dev_info->type == UBBD_DEV_TYPE_S3){
 		struct ubbd_s3_backend *s3_backend;
 
 		s3_backend = create_s3_backend();
@@ -214,6 +231,14 @@ struct ubbd_backend *backend_create(struct __ubbd_dev_info *dev_info)
 		strcpy(s3_backend->bucket_name, dev_info->s3.bucket_name);
 		s3_backend->port = dev_info->s3.port;
 		s3_backend->block_size = dev_info->s3.block_size;
+		ubbd_b->dev_size = dev_info->size;
+	} else if (dev_info->type == UBBD_DEV_TYPE_MEM){
+		struct ubbd_mem_backend *mem_backend;
+
+		mem_backend = create_mem_backend();
+		if (!mem_backend)
+			return NULL;
+		ubbd_b = &mem_backend->ubbd_b;
 		ubbd_b->dev_size = dev_info->size;
 	} else {
 		ubbd_err("Unknown dev type\n");

--- a/lib/ubbd_backends/ubbd_mem_backend.c
+++ b/lib/ubbd_backends/ubbd_mem_backend.c
@@ -1,0 +1,169 @@
+#define _GNU_SOURCE
+#include "ubbd_backend.h"
+
+#define MEM_BACKEND(ubbd_b) ((struct ubbd_mem_backend *)container_of(ubbd_b, struct ubbd_mem_backend, ubbd_b))
+
+pthread_mutex_t mem_backend_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+struct mem_block {
+	char addr[UBBD_MEM_BLK_SIZE];
+};
+
+static struct mem_block *mem_blocks[UBBD_MEM_BLK_COUNT] = { 0 };
+
+struct mem_block *mem_block_alloc(uint64_t blkid) {
+	struct mem_block *block = NULL;
+
+	block = calloc(1, sizeof(*block));
+	if (!block)
+		return NULL;
+
+	return block;
+}
+
+int get_mem_block(uint64_t offset, struct mem_block **block_ret, bool alloc) {
+	struct mem_block *block = NULL;
+	uint64_t blkid = offset >> UBBD_MEM_BLK_SHIFT;
+	int ret = 0;
+
+	pthread_mutex_lock(&mem_backend_mutex);
+	block = mem_blocks[blkid];
+	if (block) {
+		*block_ret = block;
+	} else {
+		block = mem_block_alloc(blkid);
+		if (!block) {
+			ret = -ENOMEM;
+			goto out;
+		}
+		*block_ret = mem_blocks[blkid] = block;
+	}
+out:
+	pthread_mutex_unlock(&mem_backend_mutex);
+	return ret;
+}
+
+static int mem_backend_open(struct ubbd_backend *ubbd_b)
+{
+	return 0;
+}
+
+static void mem_backend_close(struct ubbd_backend *ubbd_b)
+{
+	return;
+}
+
+static void mem_backend_release(struct ubbd_backend *ubbd_b)
+{
+	struct ubbd_mem_backend *mem_backend = MEM_BACKEND(ubbd_b);
+	int i = 0;
+
+	pthread_mutex_lock(&mem_backend_mutex);
+	for (i = 0; i < UBBD_MEM_BLK_COUNT; i++) {
+		free(mem_blocks[i]);
+		mem_blocks[i] = NULL;
+	}
+	pthread_mutex_unlock(&mem_backend_mutex);
+
+	if (mem_backend)
+		free(mem_backend);
+}
+
+static int mem_backend_writev(struct ubbd_backend *ubbd_b, struct ubbd_backend_io *io)
+{
+	struct mem_block *block = NULL;
+	int off_in_blk;
+	ssize_t count = 0;
+	int ret = 0;
+	int i;
+	ssize_t len, off_in_iov = 0;
+	void *base;
+
+	for (i = 0; i < io->iov_cnt; i++) {
+		off_in_iov = 0;
+again:
+		off_in_blk = (io->offset + count) & UBBD_MEM_BLK_MASK;
+		ret = get_mem_block(io->offset + count, &block, true);
+		if (ret) {
+			ubbd_err("failed to get mem block.\n");
+			goto out;
+		}
+
+		base = io->iov[i].iov_base + off_in_iov;
+		len = MIN(io->iov[i].iov_len - off_in_iov, UBBD_MEM_BLK_SIZE - off_in_blk);
+		memcpy(block->addr + off_in_blk, base, len);
+
+		count += len;
+		off_in_iov += len;
+		if (off_in_iov < io->iov[i].iov_len) {
+			/* iov not finished, goto next block */
+			goto again;
+		}
+	}
+
+	ret = count == io->len? 0 : -5;
+	ubbd_backend_io_finish(io, ret);
+
+out:
+	return ret;
+}
+
+static int mem_backend_readv(struct ubbd_backend *ubbd_b, struct ubbd_backend_io *io)
+{
+	struct mem_block *block = NULL;
+	int off_in_blk;
+	ssize_t count = 0;
+	int ret = 0;
+	int i;
+	ssize_t len, off_in_iov = 0;
+	void *base;
+
+	for (i = 0; i < io->iov_cnt; i++) {
+		off_in_iov = 0;
+again:
+		off_in_blk = (io->offset + count) & UBBD_MEM_BLK_MASK;
+		ret = get_mem_block(io->offset + count, &block, false);
+		if (ret) {
+			ubbd_err("failed to get mem block for read.\n");
+			goto out;
+		}
+
+		base = io->iov[i].iov_base + off_in_iov;
+		if (block) {
+			len = MIN(io->iov[i].iov_len - off_in_iov, UBBD_MEM_BLK_SIZE - off_in_blk);
+			memcpy(base, block->addr + off_in_blk, len);
+		} else {
+			len = io->iov[i].iov_len;
+			memset(base, 0, len);
+		}
+
+		count += len;
+		off_in_iov += len;
+		if (off_in_iov < io->iov[i].iov_len) {
+			/* iov not finished, goto next block */
+			goto again;
+		}
+	}
+
+	ret = count == io->len? 0 : -5;
+	ubbd_backend_io_finish(io, ret);
+
+out:
+	return ret;
+}
+
+static int mem_backend_flush(struct ubbd_backend *ubbd_b, struct ubbd_backend_io *io)
+{
+	ubbd_backend_io_finish(io, 0);
+
+	return 0;
+}
+
+struct ubbd_backend_ops mem_backend_ops = {
+	.open = mem_backend_open,
+	.close = mem_backend_close,
+	.release = mem_backend_release,
+	.writev = mem_backend_writev,
+	.readv = mem_backend_readv,
+	.flush = mem_backend_flush,
+};

--- a/lib/ubbd_devs/ubbd_dev.c
+++ b/lib/ubbd_devs/ubbd_dev.c
@@ -21,6 +21,7 @@ extern struct ubbd_dev_ops null_dev_ops;
 extern struct ubbd_dev_ops ssh_dev_ops;
 extern struct ubbd_dev_ops cache_dev_ops;
 extern struct ubbd_dev_ops s3_dev_ops;
+extern struct ubbd_dev_ops mem_dev_ops;
 
 LIST_HEAD(ubbd_dev_list);
 pthread_mutex_t ubbd_dev_list_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -66,6 +67,8 @@ struct ubbd_device *__dev_create(struct __ubbd_dev_info *info, bool force)
 		dev_ops = &ssh_dev_ops;
 	} else if (info->type == UBBD_DEV_TYPE_S3) {
 		dev_ops = &s3_dev_ops;
+	} else if (info->type == UBBD_DEV_TYPE_MEM) {
+		dev_ops = &mem_dev_ops;
 	}
 	
 	if (dev_ops == NULL) {

--- a/lib/ubbd_devs/ubbd_mem_dev.c
+++ b/lib/ubbd_devs/ubbd_mem_dev.c
@@ -1,0 +1,52 @@
+#define _GNU_SOURCE
+#include "ubbd_uio.h"
+#include "ubbd_dev.h"
+
+#define MEM_DEV(ubbd_dev) ((struct ubbd_mem_device *)container_of(ubbd_dev, struct ubbd_mem_device, ubbd_dev))
+
+struct ubbd_dev_ops mem_dev_ops;
+
+static struct ubbd_device *mem_dev_create(struct __ubbd_dev_info *info)
+{
+	struct ubbd_mem_device *mem_dev;
+	struct ubbd_device *ubbd_dev;
+
+	mem_dev = calloc(1, sizeof(*mem_dev));
+	if (!mem_dev)
+		return NULL;
+
+	ubbd_dev = &mem_dev->ubbd_dev;
+	ubbd_dev->dev_type = UBBD_DEV_TYPE_MEM;
+	ubbd_dev->dev_ops = &mem_dev_ops;
+
+	return ubbd_dev;
+}
+
+static int mem_dev_init(struct ubbd_device *ubbd_dev)
+{
+	if (ubbd_dev->dev_size > ((uint64_t)UBBD_MEM_BLK_SIZE * UBBD_MEM_BLK_COUNT)) {
+		ubbd_err("dev size for mem type is too large: %lu (max %lu)\n",
+				ubbd_dev->dev_size, ((uint64_t)UBBD_MEM_BLK_SIZE * UBBD_MEM_BLK_COUNT));
+		return -E2BIG;
+	}
+
+	ubbd_dev->dev_features.write_cache = false;
+	ubbd_dev->dev_features.fua = false;
+	ubbd_dev->dev_features.discard = false;
+	ubbd_dev->dev_features.write_zeros = false;
+
+	return 0;
+}
+
+static void mem_dev_release(struct ubbd_device *ubbd_dev)
+{
+	struct ubbd_mem_device *mem_dev = MEM_DEV(ubbd_dev);
+
+	free(mem_dev);
+}
+
+struct ubbd_dev_ops mem_dev_ops = {
+	.create = mem_dev_create,
+	.init = mem_dev_init,
+	.release = mem_dev_release,
+};

--- a/ubbdadm/main.c
+++ b/ubbdadm/main.c
@@ -446,7 +446,7 @@ int main(int argc, char **argv)
 			req_stats = &rsp.req_stats.req_stats[i];
 			fprintf(stdout, "Queue-%d:\n", i);
 			fprintf(stdout, "\tRequests:%lu\n", req_stats->reqs);
-			fprintf(stdout, "\tHandle_time:%lu\n", req_stats->reqs? req_stats->handle_time / req_stats->reqs : 0);
+			fprintf(stdout, "\tHandle_time_avg:%lu\n", req_stats->reqs? req_stats->handle_time / req_stats->reqs : 0);
 		}
 	} else if (!strcmp("req-stats-reset", command)) {
 		struct ubbd_req_stats_reset_options req_stats_reset_opts = { .ubbdid = ubbdid };

--- a/ubbdadm/main.c
+++ b/ubbdadm/main.c
@@ -116,7 +116,7 @@ static void usage(int status)
 		/* map options */
 		printf("\n\t[map options]:\n");
 
-		print_map_opt_msg("type", "device type for mapping: file, rbd, null, ssh (Experimental), cache (Experimental), s3 (Experimental)");
+		print_map_opt_msg("type", "device type for mapping: file, rbd, null, mem, ssh (Experimental), cache (Experimental), s3 (Experimental)");
 		print_map_opt_msg("devsize", "size of device to map, --devsize is required except rbd and file type");
 		print_map_opt_msg("io-timeout", "timeout before IO fail, default as 0 means no timeout.");
 		print_opt_msg("dev-share-memory-size", "share memory for each queue between userspace and kernel space, range is [4194304 (4M) - 1073741824 (1G)].");
@@ -217,6 +217,8 @@ static char *type_to_str(enum ubbd_dev_type type)
 		return "rbd";
 	else if (type == UBBD_DEV_TYPE_NULL)
 		return "null";
+	else if (type == UBBD_DEV_TYPE_MEM)
+		return "mem";
 	else if (type == UBBD_DEV_TYPE_SSH)
 		return "ssh";
 	else if (type == UBBD_DEV_TYPE_CACHE)
@@ -253,6 +255,7 @@ static int __output_dev_info_detail(struct __ubbd_dev_info *dev_info)
 		printf("\tcluster_name: %s\n", dev_info->rbd.cluster_name);
 		printf("\tuser_name: %s\n", dev_info->rbd.user_name);
 	} else if (dev_type == UBBD_DEV_TYPE_NULL) {
+	} else if (dev_type == UBBD_DEV_TYPE_MEM) {
 	} else if (dev_type == UBBD_DEV_TYPE_SSH) {
 		printf("\thostname: %s\n", dev_info->ssh.hostname);
 		printf("\tpath: %s\n", dev_info->ssh.path);


### PR DESCRIPTION
mem backend type will allocate memory to handle block IO, it is used for testing, memory backend cant upgrade online