### PR TITLE
rbd_backend: fix quiesce retval in rbd_quiesce_complete

### DIFF
--- a/lib/libubbd.c
+++ b/lib/libubbd.c
@@ -8,6 +8,7 @@
 #include "ubbd_dev.h"
 #include "utils.h"
 #include "ubbd_netlink.h"
+#include "ubbd_compat.h"
 
 /* 32M */
 #define DEFAULT_SHMEM_SIZE	(32 * 1024 *1024)

--- a/lib/ubbd_backends/ubbd_rbd_backend.c
+++ b/lib/ubbd_backends/ubbd_rbd_backend.c
@@ -4,6 +4,7 @@
 
 #include "ubbd_backend.h"
 #include "ubbd_uio.h"
+#include "ubbd_compat.h"
 
 // rbd ops
 #define RBD_BACKEND(ubbd_b) ((struct ubbd_rbd_backend *)container_of(ubbd_b, struct ubbd_rbd_backend, ubbd_b))
@@ -80,6 +81,10 @@ static void rbd_backend_quiesce_cb(void *arg)
 
 	free(dev_str);
 out:
+	ubbd_info("quiesce complete: %d\n", ret);
+	if (ret) {
+		ret = -1;
+	}
 	rbd_quiesce_complete(rbd_conn->image, rbd_conn->quiesce_handle, ret);
 }
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -34,7 +34,7 @@ int execute(char* program, char** arg_list)
 		ubbd_info("status of child is : %d\n", status);
 	}
 
-	return 0;
+	return status;
 }
 
 int ubbd_util_get_file_size(const char *filepath, uint64_t *file_size)


### PR DESCRIPTION
we need to return a negative value to rbd, to tell that quiesce fail