### PR TITLE
install_dep: fix syntax error of unary operator expected

### DIFF
--- a/install_dep.sh
+++ b/install_dep.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $UBBD_SKIP_INSTALL_DEP == "yes" ]; then
+if [ "$UBBD_SKIP_INSTALL_DEP" == "yes" ]; then
 	exit 0
 fi
 


### PR DESCRIPTION
When we don't specify a theme, $UBBD_SKIP_INSTALL_DEP expands to nothing, and the shell sees this syntax error: if [ == "yes" ].